### PR TITLE
Rework. More OO friendly interface.

### DIFF
--- a/ISO4217.php
+++ b/ISO4217.php
@@ -15,15 +15,96 @@ namespace Alcohol;
 class ISO4217
 {
     /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string
+     */
+    protected $alpha3;
+
+    /**
+     * @var int
+     */
+    protected $numeric;
+
+    /**
+     * @var int
+     */
+    protected $exp;
+
+    /**
+     * @var string|string[]
+     */
+    protected $country;
+
+    /**
+     * @param string $name
+     * @param string $alpha3
+     * @param int $numeric
+     * @param int $exp
+     * @param string|string[] $country
+     */
+    public function __construct($name, $alpha3, $numeric, $exp, $country)
+    {
+        $this->name = $name;
+        $this->alpha3 = $alpha3;
+        $this->numeric = $numeric;
+        $this->exp = $exp;
+        $this->country = $country;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAlpha3()
+    {
+        return $this->alpha3;
+    }
+
+    /**
+     * @return int
+     */
+    public function getNumeric()
+    {
+        return $this->numeric;
+    }
+
+    /**
+     * @return int
+     */
+    public function getExp()
+    {
+        return $this->exp;
+    }
+
+    /**
+     * @return string|\string[]
+     */
+    public function getCountry()
+    {
+        return $this->country;
+    }
+
+    /**
      * @param string $code
      * @return array
      * @throws \RuntimeException
      */
-    public function getByCode($code)
+    public static function findByCode($code)
     {
-        foreach ($this->currencies as $currency) {
+        foreach (static::$currencies as $currency) {
             if (0 === strcasecmp($code, $currency['alpha3'])) {
-                return $currency;
+                return static::create($currency);
             }
         }
 
@@ -32,32 +113,32 @@ class ISO4217
 
     /**
      * @param string $alpha3
-     * @return array
+     * @return static
      * @throws \InvalidArgumentException
      */
-    public function getByAlpha3($alpha3)
+    public static function findByAlpha3($alpha3)
     {
         if (!preg_match('/^[a-zA-Z]{3}$/', $alpha3)) {
             throw new \InvalidArgumentException('Not a valid alpha3: ' . $alpha3);
         }
 
-        return $this->getByCode($alpha3);
+        return static::findByCode($alpha3);
     }
 
     /**
      * @param string $numeric
-     * @return array
+     * @return static
      * @throws \RuntimeException
      */
-    public function getByNumeric($numeric)
+    public static function findByNumeric($numeric)
     {
         if (!preg_match('/^[0-9]{3}$/', $numeric)) {
             throw new \InvalidArgumentException('Not a valid numeric: ' . $numeric);
         }
 
-        foreach ($this->currencies as $currency) {
+        foreach (static::$currencies as $currency) {
             if (0 === strcasecmp($numeric, $currency['numeric'])) {
-                return $currency;
+                return static::create($currency);
             }
         }
 
@@ -65,15 +146,33 @@ class ISO4217
     }
 
     /**
-     * @return array
+     * @return static[]
      */
-    public function getAll()
+    public static function findAll()
     {
-        return $this->currencies;
+        $currencies = array();
+
+        foreach (static::$currencies as $currency) {
+            $currencies[] = static::create($currency);
+        }
+
+        return $currencies;
     }
 
-    /** @var array */
-    protected $currencies = array(
+    /**
+     * @param string[] $currency
+     *
+     * @return static
+     */
+    protected static function create(array $currency)
+    {
+        return new static($currency['name'], $currency['alpha3'], $currency['numeric'], $currency['exp'], $currency['country']);
+    }
+
+    /**
+     * @var array
+     */
+    protected static $currencies = array(
         array(
             'name' => 'UAE Dirham',
             'alpha3' => 'AED',

--- a/ISO4217Test.php
+++ b/ISO4217Test.php
@@ -20,10 +20,9 @@ class ISO4217Test extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessageRegExp /^Not a valid alpha3: .*$/
      */
-    public function testGetByAlpha3Invalid($alpha3)
+    public function testFindByAlpha3Invalid($alpha3)
     {
-        $iso4217 = new ISO4217;
-        $iso4217->getByAlpha3($alpha3);
+        ISO4217::findByAlpha3($alpha3);
     }
 
     /**
@@ -31,10 +30,9 @@ class ISO4217Test extends \PHPUnit_Framework_TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage ISO 4217 does not contain: ZZZ
      */
-    public function testGetByAlpha3Unknown()
+    public function testFindByAlpha3Unknown()
     {
-        $iso4217 = new ISO4217;
-        $iso4217->getByAlpha3('ZZZ');
+        ISO4217::findByAlpha3('ZZZ');
     }
 
     /**
@@ -43,10 +41,15 @@ class ISO4217Test extends \PHPUnit_Framework_TestCase
      * @param string $alpha3
      * @param array $expected
      */
-    public function testGetByAlpha3($alpha3, array $expected)
+    public function testFindByAlpha3($alpha3, array $expected)
     {
-        $iso4217 = new ISO4217;
-        $this->assertEquals($expected, $iso4217->getByAlpha3($alpha3));
+        $currency = ISO4217::findByAlpha3($alpha3);
+
+        $this->assertEquals($expected['name'], $currency->getName());
+        $this->assertEquals($expected['alpha3'], $currency->getAlpha3());
+        $this->assertEquals($expected['numeric'], $currency->getNumeric());
+        $this->assertEquals($expected['exp'], $currency->getExp());
+        $this->assertEquals($expected['country'], $currency->getCountry());
     }
 
     /**
@@ -56,10 +59,9 @@ class ISO4217Test extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessageRegExp /^Not a valid numeric: .*$/
      */
-    public function testGetByNumericInvalid($numeric)
+    public function testFindByNumericInvalid($numeric)
     {
-        $iso4217 = new ISO4217;
-        $iso4217->getByNumeric($numeric);
+        ISO4217::findByNumeric($numeric);
     }
 
     /**
@@ -67,10 +69,9 @@ class ISO4217Test extends \PHPUnit_Framework_TestCase
      * @expectedException \RuntimeException
      * @expectedExceptionMessage ISO 4217 does not contain: 000
      */
-    public function testGetByNumericUnknown()
+    public function testFindByNumericUnknown()
     {
-        $iso4217 = new ISO4217;
-        $iso4217->getByNumeric('000');
+        ISO4217::findByNumeric('000');
     }
 
     /**
@@ -79,20 +80,28 @@ class ISO4217Test extends \PHPUnit_Framework_TestCase
      * @param string $numeric
      * @param array $expected
      */
-    public function testGetByNumeric($numeric, $expected)
+    public function testFindByNumeric($numeric, array $expected)
     {
-        $iso4217 = new ISO4217;
-        $this->assertEquals($expected, $iso4217->getByNumeric($numeric));
+        $currency = ISO4217::findByNumeric($numeric);
+
+        $this->assertEquals($expected['name'], $currency->getName());
+        $this->assertEquals($expected['alpha3'], $currency->getAlpha3());
+        $this->assertEquals($expected['numeric'], $currency->getNumeric());
+        $this->assertEquals($expected['exp'], $currency->getExp());
+        $this->assertEquals($expected['country'], $currency->getCountry());
     }
 
     /**
-     * @testdox Calling getAll returns an array with all elements.
+     * @testdox Calling findAll returns an array of ISO4217 instances.
      */
-    public function testGetAll()
+    public function testFindAll()
     {
-        $iso4217 = new ISO4217;
-        $this->assertInternalType('array', $iso4217->getAll());
-        $this->assertCount(157, $iso4217->getAll());
+        $currencies = ISO4217::findAll();
+
+        $this->assertInternalType('array', $currencies);
+        $this->assertCount(157, $currencies);
+
+        $this->assertContainsOnly('Alcohol\ISO4217', $currencies);
     }
 
     /**
@@ -132,10 +141,10 @@ class ISO4217Test extends \PHPUnit_Framework_TestCase
      */
     private function getCurrencies($indexedBy)
     {
-        $reflected = new \ReflectionClass('Alcohol\ISO4217');
-        $currencies = $reflected->getProperty('currencies');
-        $currencies->setAccessible(true);
-        $currencies = $currencies->getValue(new ISO4217);
+        $rp = new \ReflectionProperty('Alcohol\ISO4217', 'currencies');
+        $rp->setAccessible(true);
+        $currencies = $rp->getValue('Alcohol\ISO4217');
+        $rp->setAccessible(false);
 
         return array_reduce(
             $currencies,

--- a/README.md
+++ b/README.md
@@ -36,34 +36,17 @@ Code:
 ``` php
 <?php
 
-$iso4217 = new Alcohol\ISO4217;
+$euro = new \Alcohol\ISO4217::findByAlpha3('EUR');
 
-$iso4217->getByAlpha3('EUR');
 // or
-$iso4217->getByNumeric('978');
 
-// also
-$iso4217->getAll();
-```
+$euro = new \Alcohol\ISO4217::findByNumeric('978');
 
-Result:
-
-```
-Array
-(
-    [name] => Euro
-    [alpha3] => EUR
-    [numeric] => 978
-    [exp] => 2
-    [country] => Array
-        (
-            [0] => AD
-            [1] => AT
-            ...
-            [30] => YT
-            [31] => ZW
-        )
-)
+$euro->getName();    // Euro
+$euro->getAlpha3();  // EUR
+$euro->getNumeric(); // 978
+$euro->getExp();     // 2
+$euro->getCountry(); // ['AD', 'AT' ... 'YT', 'ZW']
 ```
 
 ## Excluded


### PR DESCRIPTION
Changes:

* Make all current methods getByXXX and getAll static.
* As well as currencies property.
* Rename all getByXX methods to findByXXX ones.
* Rename getAll to findAll method.
* Now all find method returns instance of ISO4217 with some nice getters.

Code:

``` php
<?php

$euro = new \Alcohol\ISO4217::findByAlpha3('EUR');

// or

$euro = new \Alcohol\ISO4217::findByNumeric('978');

$euro->getName();    // Euro
$euro->getAlpha3();  // EUR
$euro->getNumeric(); // 978
$euro->getExp();     // 2
$euro->getCountry(); // ['AD', 'AT' ... 'YT', 'ZW']
```

TODO:

* identity map