### PR TITLE
Reflect replacement of BYR by BYN

### DIFF
--- a/ISO4217.php
+++ b/ISO4217.php
@@ -271,9 +271,9 @@ class ISO4217
         ],
         [
             'name' => 'Belarussian Ruble',
-            'alpha3' => 'BYR',
-            'numeric' => '974',
-            'exp' => 0,
+            'alpha3' => 'BYN',
+            'numeric' => '933',
+            'exp' => 2,
             'country' => 'BY',
         ],
         [


### PR DESCRIPTION
I noticed that #11 has not been merged. At least BYR was planned to be replaced by BYN, which hasn't happened since.

BYR has been replaced: https://en.wikipedia.org/wiki/Belarusian_ruble

Credit for this change goes to https://github.com/eidng8 whose original PR was not merged for
other reasons.