### PR TITLE
Update MGA and MRU

### DIFF
--- a/ISO4217.php
+++ b/ISO4217.php
@@ -769,7 +769,7 @@ class ISO4217
             'name' => 'Malagasy Ariary',
             'alpha3' => 'MGA',
             'numeric' => '969',
-            'exp' => 0,
+            'exp' => 2,
             'country' => 'MG',
         ],
         [
@@ -804,7 +804,7 @@ class ISO4217
             'name' => 'Mauritanian Ouguiya',
             'alpha3' => 'MRU',
             'numeric' => '929',
-            'exp' => 1,
+            'exp' => 2,
             'country' => 'MR',
         ],
         [


### PR DESCRIPTION
Both MGA and MRU are weird in the fact they're non-decimal - both have a subunit of 1/5 of the main unit.

However, the official ISO4217 list has both of them down with an exponent of '2' (see https://www.currency-iso.org/en/home/tables/table-a1.html).