### PR TITLE
Drop PHP 5.4 support and add support for PHP 8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: Continuous Integration
+
+on: [push]
+
+jobs:
+
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['7.3', '7.4', '8.0.0RC4']
+        dependencies: [locked, lowest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies from .lock file
+        run: docker run --rm --volume $(pwd):/workdir --workdir /workdir composer install --no-interaction --no-progress
+      - name: Update dependencies versions to lowest allowed by constraints
+        if: contains(matrix.dependencies, 'lowest')
+        run: docker run --rm --volume $(pwd):/workdir --workdir /workdir composer update --no-interaction --no-progress --prefer-lowest
+      - name: Run PHPUnit tests
+        run: docker run --rm --volume $(pwd):/workdir --workdir /workdir php:${{ matrix.php-version }}-cli-alpine vendor/bin/phpunit  --coverage-text

--- a/ISO4217.php
+++ b/ISO4217.php
@@ -92,7 +92,7 @@ class ISO4217
      *
      * @var array
      */
-    protected array $currencies = [
+    protected $currencies = [
         [
             'name' => 'UAE Dirham',
             'alpha3' => 'AED',

--- a/ISO4217.php
+++ b/ISO4217.php
@@ -23,7 +23,7 @@ class ISO4217
      *
      * @return array
      */
-    public function getByCode($code)
+    public function getByCode($code): array
     {
         foreach ($this->currencies as $currency) {
             if (0 === strcasecmp($code, $currency['alpha3']) ||
@@ -46,7 +46,7 @@ class ISO4217
      *
      * @return array
      */
-    public function getByAlpha3($alpha3)
+    public function getByAlpha3($alpha3): array
     {
         if (!preg_match('/^[a-zA-Z]{3}$/', $alpha3)) {
             throw new \DomainException('Not a valid alpha3: '.$alpha3);
@@ -66,7 +66,7 @@ class ISO4217
      *
      * @return array
      */
-    public function getByNumeric($numeric)
+    public function getByNumeric($numeric): array
     {
         if (!preg_match('/^[0-9]{3}$/', $numeric)) {
             throw new \DomainException('Not a valid numeric: '.$numeric);
@@ -82,7 +82,7 @@ class ISO4217
      *
      * @return array
      */
-    public function getAll()
+    public function getAll(): array
     {
         return $this->currencies;
     }
@@ -92,7 +92,7 @@ class ISO4217
      *
      * @var array
      */
-    protected $currencies = [
+    protected array $currencies = [
         [
             'name' => 'UAE Dirham',
             'alpha3' => 'AED',

--- a/ISO4217.php
+++ b/ISO4217.php
@@ -17,7 +17,7 @@ class ISO4217
     /**
      * @api
      *
-     * @param string $code
+     * @param string|int $code
      *
      * @throws \OutOfBoundsException
      *

--- a/ISO4217Test.php
+++ b/ISO4217Test.php
@@ -16,10 +16,10 @@ class ISO4217Test extends TestCase
     /**
      * @testdox Calling getByAlpha3 with an invalid alpha3 throws a DomainException.
      *
-     * @param string $alpha3
+     * @param string|int $alpha3
      * @dataProvider invalidAlpha3Provider
      */
-    public function testGetByAlpha3Invalid($alpha3)
+    public function testGetByAlpha3Invalid($alpha3): void
     {
         $this->expectException(\DomainException::class);
         $this->expectExceptionMessageMatches('/^Not a valid alpha3: .*$/');
@@ -31,7 +31,7 @@ class ISO4217Test extends TestCase
     /**
      * @testdox Calling getByAlpha3 with an unknown alpha3 throws a OutOfBoundsException.
      */
-    public function testGetByAlpha3Unknown()
+    public function testGetByAlpha3Unknown(): void
     {
         $this->expectException(\OutOfBoundsException::class);
         $this->expectExceptionMessage('ISO 4217 does not contain: ZZZ');
@@ -47,7 +47,7 @@ class ISO4217Test extends TestCase
      * @param string $alpha3
      * @param array $expected
      */
-    public function testGetByAlpha3($alpha3, array $expected)
+    public function testGetByAlpha3(string $alpha3, array $expected): void
     {
         $iso4217 = new ISO4217();
         $this->assertEquals($expected, $iso4217->getByAlpha3($alpha3));
@@ -59,7 +59,7 @@ class ISO4217Test extends TestCase
      * @param string $numeric
      * @dataProvider invalidNumericProvider
      */
-    public function testGetByNumericInvalid($numeric)
+    public function testGetByNumericInvalid(string $numeric): void
     {
         $this->expectException(\DomainException::class);
         $this->expectExceptionMessageMatches('/^Not a valid numeric: .*$/');
@@ -71,7 +71,7 @@ class ISO4217Test extends TestCase
     /**
      * @testdox Calling getByNumeric with an unknown numeric throws a OutOfBoundsException.
      */
-    public function testGetByNumericUnknown()
+    public function testGetByNumericUnknown(): void
     {
         $this->expectException(\OutOfBoundsException::class);
         $this->expectExceptionMessage('ISO 4217 does not contain: 000');
@@ -87,7 +87,7 @@ class ISO4217Test extends TestCase
      * @param string $numeric
      * @param array $expected
      */
-    public function testGetByNumeric($numeric, $expected)
+    public function testGetByNumeric(string $numeric, array $expected): void
     {
         $iso4217 = new ISO4217();
         $this->assertEquals($expected, $iso4217->getByNumeric($numeric));
@@ -96,7 +96,7 @@ class ISO4217Test extends TestCase
     /**
      * @testdox Calling getAll returns an array with all elements.
      */
-    public function testGetAll()
+    public function testGetAll(): void
     {
         $iso4217 = new ISO4217();
         $this->assertIsArray($iso4217->getAll());
@@ -106,7 +106,7 @@ class ISO4217Test extends TestCase
     /**
      * @return array
      */
-    public function invalidAlpha3Provider()
+    public function invalidAlpha3Provider(): array
     {
         return [['ZZ'], ['ZZZZ'], [12], [1234]];
     }
@@ -114,7 +114,7 @@ class ISO4217Test extends TestCase
     /**
      * @return array
      */
-    public function alpha3Provider()
+    public function alpha3Provider(): array
     {
         return $this->getCurrencies('alpha3');
     }
@@ -122,7 +122,7 @@ class ISO4217Test extends TestCase
     /**
      * @return array
      */
-    public function invalidNumericProvider()
+    public function invalidNumericProvider(): array
     {
         return [['00'], ['0000'], ['ZZ'], ['ZZZZ']];
     }
@@ -130,7 +130,7 @@ class ISO4217Test extends TestCase
     /**
      * @return array
      */
-    public function numericProvider()
+    public function numericProvider(): array
     {
         return $this->getCurrencies('numeric');
     }
@@ -138,7 +138,7 @@ class ISO4217Test extends TestCase
     /**
      * @return array
      */
-    private function getCurrencies($indexedBy)
+    private function getCurrencies(string $indexedBy): array
     {
         $reflected = new \ReflectionClass('Alcohol\ISO4217');
         $currencies = $reflected->getProperty('currencies');

--- a/ISO4217Test.php
+++ b/ISO4217Test.php
@@ -18,22 +18,24 @@ class ISO4217Test extends TestCase
      *
      * @param string $alpha3
      * @dataProvider invalidAlpha3Provider
-     * @expectedException \DomainException
-     * @expectedExceptionMessageRegExp /^Not a valid alpha3: .*$/
      */
     public function testGetByAlpha3Invalid($alpha3)
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessageMatches('/^Not a valid alpha3: .*$/');
+
         $iso4217 = new ISO4217();
         $iso4217->getByAlpha3($alpha3);
     }
 
     /**
      * @testdox Calling getByAlpha3 with an unknown alpha3 throws a OutOfBoundsException.
-     * @expectedException \OutOfBoundsException
-     * @expectedExceptionMessage ISO 4217 does not contain: ZZZ
      */
     public function testGetByAlpha3Unknown()
     {
+        $this->expectException(\OutOfBoundsException::class);
+        $this->expectExceptionMessage('ISO 4217 does not contain: ZZZ');
+
         $iso4217 = new ISO4217();
         $iso4217->getByAlpha3('ZZZ');
     }
@@ -56,22 +58,24 @@ class ISO4217Test extends TestCase
      *
      * @param string $numeric
      * @dataProvider invalidNumericProvider
-     * @expectedException \DomainException
-     * @expectedExceptionMessageRegExp /^Not a valid numeric: .*$/
      */
     public function testGetByNumericInvalid($numeric)
     {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessageMatches('/^Not a valid numeric: .*$/');
+
         $iso4217 = new ISO4217();
         $iso4217->getByNumeric($numeric);
     }
 
     /**
      * @testdox Calling getByNumeric with an unknown numeric throws a OutOfBoundsException.
-     * @expectedException \OutOfBoundsException
-     * @expectedExceptionMessage ISO 4217 does not contain: 000
      */
     public function testGetByNumericUnknown()
     {
+        $this->expectException(\OutOfBoundsException::class);
+        $this->expectExceptionMessage('ISO 4217 does not contain: 000');
+
         $iso4217 = new ISO4217();
         $iso4217->getByNumeric('000');
     }
@@ -95,7 +99,7 @@ class ISO4217Test extends TestCase
     public function testGetAll()
     {
         $iso4217 = new ISO4217();
-        $this->assertInternalType('array', $iso4217->getAll());
+        $this->assertIsArray($iso4217->getAll());
         $this->assertCount(156, $iso4217->getAll());
     }
 

--- a/ISO4217Test.php
+++ b/ISO4217Test.php
@@ -136,6 +136,8 @@ class ISO4217Test extends TestCase
     }
 
     /**
+     * @param string $indexedBy
+     *
      * @return array
      */
     private function getCurrencies(string $indexedBy): array

--- a/ISO4217Test.php
+++ b/ISO4217Test.php
@@ -147,7 +147,7 @@ class ISO4217Test extends TestCase
 
         return array_reduce(
             $currencies,
-            function (array $carry, array $currency) use ($indexedBy) {
+            static function (array $carry, array $currency) use ($indexedBy) {
                 $carry[] = [$currency[$indexedBy], $currency];
 
                 return $carry;

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5",
+    "phpunit/phpunit": "^9.3",
     "phpunit/php-invoker": "@stable"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "source": "https://github.com/alcohol/iso4217"
   },
   "require": {
-    "php": "^5.4 || ^7.0"
+    "php": "^7.0 || ^8.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
# PHP 8 Support
PHP 8 will be released this year and I think this library needs to move on to be compatible with PHP 8.

## Changes: 
- PHP 5 support is dropped to allow PHP 8 support.
- PHPUnit 9 is now used for testing (compatible with PHP 7 and PHP 8).
- Types added to `return` and `params` when possible.
- Tests updated to be compatible with PHPUnit 9.

## Tests
- [x] PHP 7
- [x] PHP 8