### PR TITLE
drop phpstan/phpstan-php-parser

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,5 @@
 includes:
   - tools/phpstan/vendor/phpstan/phpstan-deprecation-rules/rules.neon
-  - tools/phpstan/vendor/phpstan/phpstan-php-parser/extension.neon
   - tools/phpstan/vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,7 +1,6 @@
 {
     "require": {
         "phpstan/phpstan": "*",
-        "phpstan/phpstan-php-parser": "*",
         "phpstan/phpstan-deprecation-rules": "*",
         "phpstan/phpstan-strict-rules": "*"
     }


### PR DESCRIPTION
the phpstan/phpstan-php-parser package is obsolete and you should no longer use it in your composer.json/composer.lock

see https://github.com/phpstan/phpstan-php-parser

![grafik](https://github.com/user-attachments/assets/9670d43c-fa92-4965-ba04-67403a47a322)
